### PR TITLE
Internalize DotExtensions dependencies

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,8 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.9" />
-    <PackageVersion Include="DotExtensions.Memory" Version="10.3.3" />
-    <PackageVersion Include="DotExtensions" Version="10.3.3" />
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.119">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EnhancedLinq.Async/EnhancedLinq.Async.csproj
+++ b/src/EnhancedLinq.Async/EnhancedLinq.Async.csproj
@@ -30,7 +30,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotExtensions"/>
         <PackageReference Include="Meziantou.Analyzer">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EnhancedLinq.Memory/Deferred/DeferredMemoryIndexExtensions.cs
+++ b/src/EnhancedLinq.Memory/Deferred/DeferredMemoryIndexExtensions.cs
@@ -30,7 +30,8 @@ public static class DeferredMemoryIndexExtensions
         /// <exception cref="InvalidOperationException">Thrown when the <see cref="Memory{T}" /> is empty.</exception>
         public IEnumerable<(int Index, TSource Item)> Index()
         {
-            InvalidOperationException.ThrowIfMemoryIsEmpty(memory);
+            if (memory.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptyMemory);
 
             int index = 0;
 
@@ -60,7 +61,8 @@ public static class DeferredMemoryIndexExtensions
         /// <exception cref="InvalidOperationException">Thrown when the <see cref="ReadOnlyMemory{T}" /> is empty.</exception>
         public IEnumerable<(int Index, TSource Item)> Index()
         {
-            InvalidOperationException.ThrowIfMemoryIsEmpty(memory);
+            if (memory.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptyMemory);
 
             int index = 0;
 

--- a/src/EnhancedLinq.Memory/EnhancedLinq.Memory.csproj
+++ b/src/EnhancedLinq.Memory/EnhancedLinq.Memory.csproj
@@ -30,8 +30,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotExtensions.Memory" />
-        <PackageReference Include="DotExtensions"/>
         <PackageReference Include="Meziantou.Analyzer">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EnhancedLinq.Memory/GlobalUsings.cs
+++ b/src/EnhancedLinq.Memory/GlobalUsings.cs
@@ -4,7 +4,5 @@ global using System;
 global using System.Collections;
 global using System.Collections.Generic;
 global using System.Numerics;
-global using DotExtensions.Memory;
-global using DotExtensions.Memory.Exceptions;
 global using EnhancedLinq.Collections;
 global using EnhancedLinq.Memory.Internals.Localizations;

--- a/src/EnhancedLinq.Memory/Immediate/ImmediateMemoryForEachExtensions.cs
+++ b/src/EnhancedLinq.Memory/Immediate/ImmediateMemoryForEachExtensions.cs
@@ -25,7 +25,8 @@ public static class ImmediateMemoryForEachExtensions
         /// <param name="action">The action to apply to each element in the span.</param>
         public void ForEach(Action<T> action)
         {
-            InvalidOperationException.ThrowIfSpanIsEmpty(target);
+            if (target.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptySpan);
             ArgumentNullException.ThrowIfNull(action);
 
             for (int index = 0; index < target.Length; index++)
@@ -43,7 +44,8 @@ public static class ImmediateMemoryForEachExtensions
         /// <param name="action">The func to apply to each element in the span.</param>
         public void ForEach(Func<T, T> action)
         {
-            InvalidOperationException.ThrowIfSpanIsEmpty(target);
+            if (target.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptySpan);
             ArgumentNullException.ThrowIfNull(action);
 
             for (int i = 0; i < target.Length; i++) 
@@ -61,7 +63,8 @@ public static class ImmediateMemoryForEachExtensions
         /// <param name="action">The action to apply to each element in the memory.</param>
         public Memory<T> ForEach(Action<T> action)
         {
-            InvalidOperationException.ThrowIfMemoryIsEmpty(target);
+            if (target.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptyMemory);
             ArgumentNullException.ThrowIfNull(action);
 
             T[] array = new T[target.Length];
@@ -83,7 +86,8 @@ public static class ImmediateMemoryForEachExtensions
         /// <param name="action">The action to apply to each element in the memory.</param>
         public Memory<T> ForEach(Func<T, T> action)
         {
-            InvalidOperationException.ThrowIfMemoryIsEmpty(target);
+            if (target.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptyMemory);
             ArgumentNullException.ThrowIfNull(action);
 
             T[] array = new T[target.Length];

--- a/src/EnhancedLinq.Memory/Immediate/ImmediateMemoryLastIndexExtensions.cs
+++ b/src/EnhancedLinq.Memory/Immediate/ImmediateMemoryLastIndexExtensions.cs
@@ -27,7 +27,8 @@ public static class ImmediateMemoryLastIndexExtensions
         {
             get
             {
-                InvalidOperationException.ThrowIfSpanIsEmpty(span);
+                if (span.IsEmpty)
+                    throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptySpan);
                 return span.Length - 1;
             }
         }
@@ -46,7 +47,8 @@ public static class ImmediateMemoryLastIndexExtensions
         {
             get
             {
-                InvalidOperationException.ThrowIfSpanIsEmpty(span);
+                if (span.IsEmpty)
+                    throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptySpan);
                 return span.Length - 1;
             }
         }
@@ -65,7 +67,8 @@ public static class ImmediateMemoryLastIndexExtensions
         {
             get
             {
-                InvalidOperationException.ThrowIfMemoryIsEmpty(memory);
+                if (memory.IsEmpty)
+                    throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptyMemory);
                 return memory.Length - 1;
             }
         }
@@ -84,7 +87,8 @@ public static class ImmediateMemoryLastIndexExtensions
         {
             get
             {
-                InvalidOperationException.ThrowIfMemoryIsEmpty(memory);
+                if (memory.IsEmpty)
+                    throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptyMemory);
                 return memory.Length - 1;
             }
         }

--- a/src/EnhancedLinq.Memory/Immediate/Linq/ImmediateMemoryFirstAndLastExtensions.cs
+++ b/src/EnhancedLinq.Memory/Immediate/Linq/ImmediateMemoryFirstAndLastExtensions.cs
@@ -24,7 +24,8 @@ public static class ImmediateMemoryFirstAndLastExtensions
         /// <exception cref="InvalidOperationException">Thrown if the <see cref="Span{T}" /> contains zero items.</exception>
         public T First()
         {
-            InvalidOperationException.ThrowIfSpanIsEmpty(target);
+            if (target.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptySpan);
             
             return target[0];
         }
@@ -107,7 +108,8 @@ public static class ImmediateMemoryFirstAndLastExtensions
         /// <exception cref="InvalidOperationException">Thrown if the Span contains zero items.</exception>
         public T Last()
         {
-            InvalidOperationException.ThrowIfSpanIsEmpty(target);
+            if (target.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptySpan);
 
 #if NET8_0_OR_GREATER
             return target[^1];
@@ -173,7 +175,8 @@ public static class ImmediateMemoryFirstAndLastExtensions
         /// <exception cref="InvalidOperationException">Thrown if the <see cref="ReadOnlySpan{T}" /> contains zero items.</exception>
         public T First()
         {
-            InvalidOperationException.ThrowIfSpanIsEmpty(target);
+            if (target.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptySpan);
 
             return target[0];
         }
@@ -249,7 +252,8 @@ public static class ImmediateMemoryFirstAndLastExtensions
         /// <exception cref="InvalidOperationException">Thrown if the <see cref="ReadOnlySpan{T}" /> contains zero items.</exception>
         public T Last()
         {
-            InvalidOperationException.ThrowIfSpanIsEmpty(target);
+            if (target.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptySpan);
             
 #if NET8_0_OR_GREATER
             return target[^1];
@@ -309,7 +313,8 @@ public static class ImmediateMemoryFirstAndLastExtensions
         /// <returns>The first element of the Memory sequence.</returns>
         public T First()
         {
-            InvalidOperationException.ThrowIfMemoryIsEmpty(target);
+            if (target.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptyMemory);
 
             foreach (T item in target.Span)
                 return item;
@@ -366,7 +371,8 @@ public static class ImmediateMemoryFirstAndLastExtensions
         /// <returns>The last element of the Memory sequence.</returns>
         public T Last()
         {
-            InvalidOperationException.ThrowIfMemoryIsEmpty(target);
+            if (target.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptyMemory);
             
             return target.ElementAt(target.LastIndex);
         }
@@ -442,7 +448,8 @@ public static class ImmediateMemoryFirstAndLastExtensions
         /// <returns>The first element of the <see cref="ReadOnlyMemory{T}" />  sequence.</returns>
         public T First()
         {
-            InvalidOperationException.ThrowIfMemoryIsEmpty(target);
+            if (target.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptyMemory);
 
             foreach (T item in target.Span) 
                 return item;
@@ -513,7 +520,8 @@ public static class ImmediateMemoryFirstAndLastExtensions
         /// <returns>The last element of the <see cref="ReadOnlyMemory{T}" />  sequence.</returns>
         public T Last()
         {
-            InvalidOperationException.ThrowIfMemoryIsEmpty(target);
+            if (target.IsEmpty)
+                throw new InvalidOperationException(Resources.Exceptions_InvalidOperation_EmptyMemory);
             
             return target.ElementAt(target.LastIndex);
         }

--- a/src/EnhancedLinq.Memory/Immediate/Maths/ImmediateMemoryAverageExtensions.cs
+++ b/src/EnhancedLinq.Memory/Immediate/Maths/ImmediateMemoryAverageExtensions.cs
@@ -8,8 +8,6 @@
     */
 
 #if NET8_0_OR_GREATER
-using DotExtensions.Numbers;
-
 namespace EnhancedLinq.Memory.Immediate.Maths;
 
 /// <summary>
@@ -28,7 +26,7 @@ public static class ImmediateMemoryAverageExtensions
         {
             TNumber sum = source.Sum();
 
-            return sum / source.Length.ToNumber<TNumber>();
+            return sum / TNumber.CreateTruncating(source.Length);
         }
     }
 
@@ -44,7 +42,7 @@ public static class ImmediateMemoryAverageExtensions
         {
             TNumber sum = source.Sum();
 
-            return sum / source.Length.ToNumber<TNumber>();
+            return sum / TNumber.CreateTruncating(source.Length);
         }
     }
 

--- a/src/EnhancedLinq.Memory/Immediate/Ranges/ImmediateMemoryGetRangeExtensions.cs
+++ b/src/EnhancedLinq.Memory/Immediate/Ranges/ImmediateMemoryGetRangeExtensions.cs
@@ -8,7 +8,6 @@
     */
 
 using System.Linq;
-using DotExtensions.Numbers;
 
 namespace EnhancedLinq.Memory.Immediate.Ranges;
 
@@ -102,7 +101,7 @@ public static class ImmediateMemoryGetRangeExtensions
         {
             ArgumentNullException.ThrowIfNull(indices);
 
-            if (indices.IsIncrementedNumberRange(1))
+            if (IsIncrementedNumberRange(indices, 1))
                 return target.GetRange(indices.Min(), indices.Max());
 
             T[] array = new T[indices.Count];
@@ -119,5 +118,31 @@ public static class ImmediateMemoryGetRangeExtensions
 
             return new Span<T>(array);
         }
+    }
+
+    private static bool IsIncrementedNumberRange(ICollection<int> indices, int step)
+    {
+        if (indices.Count < 2)
+            return true;
+
+        int previous = -1;
+        bool isFirst = true;
+
+        foreach (int index in indices)
+        {
+            if (isFirst)
+            {
+                previous = index;
+                isFirst = false;
+                continue;
+            }
+
+            if (index - previous != step)
+                return false;
+
+            previous = index;
+        }
+
+        return true;
     }
 }

--- a/src/EnhancedLinq.Memory/Immediate/Ranges/ImmediateMemoryInsertRangeExtensions.cs
+++ b/src/EnhancedLinq.Memory/Immediate/Ranges/ImmediateMemoryInsertRangeExtensions.cs
@@ -7,8 +7,6 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/.
     */
 
-using DotExtensions.Memory.Spans;
-
 namespace EnhancedLinq.Memory.Immediate.Ranges;
 
 /// <summary>
@@ -32,7 +30,9 @@ public static class ImmediateMemoryInsertRangeExtensions
 
             int newLength = span.Length + elements.Count;
 
-            span.Resize(newLength);
+            T[] newArray = new T[newLength];
+            span.CopyTo(newArray);
+            span = new Span<T>(newArray);
 
             int i = startIndex;
 

--- a/src/EnhancedLinq/Deferred/DeferredElementsAtExtensions.cs
+++ b/src/EnhancedLinq/Deferred/DeferredElementsAtExtensions.cs
@@ -37,6 +37,7 @@ public static class DeferredElementsAtExtensions
                 new ElementsAtEnumerator<TSource>(source, indices));
         }
         
+#if !NETSTANDARD2_0
         /// <summary>
         /// Returns a sequence of elements from the specified source, 
         /// where the index of each element in the returned sequence corresponds to an index in the provided indices.
@@ -47,6 +48,7 @@ public static class DeferredElementsAtExtensions
         /// <returns>A new sequence containing the elements at the specified indexes from the original source.</returns>
         public IEnumerable<TSource> ElementsAt(Range range)
             =>source.ElementsAt(range.Start.Value, Math.Abs(range.Start.Value - range.End.Value));
+#endif
         
         /// <summary>
         /// Returns a sequence of elements from the specified source, 

--- a/src/EnhancedLinq/EnhancedLinq.csproj
+++ b/src/EnhancedLinq/EnhancedLinq.csproj
@@ -49,7 +49,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotExtensions"/>
         <PackageReference Include="Meziantou.Analyzer">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EnhancedLinq/Immediate/Lists/Ranges/ImmediateListNumberRangeExtensions.cs
+++ b/src/EnhancedLinq/Immediate/Lists/Ranges/ImmediateListNumberRangeExtensions.cs
@@ -9,7 +9,6 @@
 
 #if NET8_0_OR_GREATER
 using System.Numerics;
-using DotExtensions.Numbers;
 #endif
 
 namespace EnhancedLinq.Immediate.Lists.Ranges;
@@ -40,7 +39,7 @@ public static class ImmediateListNumberRangeExtensions
             if (startIndex + count >= TNumber.MaxValue)
                 throw new ArgumentException(Resources.Exceptions_Count_LessThanZero, nameof(count));
 
-            int arrayCount = count.ToDestinationNumber<TNumber, int>() + 1;
+            int arrayCount = int.CreateTruncating(count) + 1;
         
             TNumber[] output = new TNumber[arrayCount];
 
@@ -69,8 +68,8 @@ public static class ImmediateListNumberRangeExtensions
 
             if (startIndex + count > TNumber.MaxValue)
                 throw new ArgumentException(Resources.Exceptions_Count_LessThanZero, nameof(count));
-        
-            List<TNumber> output = new List<TNumber>(count.ToDestinationNumber<TNumber, int>() + 1);
+
+            List<TNumber> output = new List<TNumber>(int.CreateTruncating(count) + 1);
         
             for (TNumber i = startIndex; i < count; i++)
             {

--- a/src/EnhancedLinq/Internals/Localizations/Resources.Designer.cs
+++ b/src/EnhancedLinq/Internals/Localizations/Resources.Designer.cs
@@ -141,6 +141,15 @@ namespace EnhancedLinq.Internals.Localizations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Source StringSegment cannot be null or whitespace..
+        /// </summary>
+        internal static string Exceptions_StringSegment_NullOrWhitespace {
+            get {
+                return ResourceManager.GetString("Exceptions.StringSegment.NullOrWhitespace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value not found at index {x} within collection {y}..
         /// </summary>
         internal static string Exceptions_ValueNotFound_AtIndex {

--- a/src/EnhancedLinq/Internals/Localizations/Resources.resx
+++ b/src/EnhancedLinq/Internals/Localizations/Resources.resx
@@ -51,4 +51,7 @@
     <data name="Exceptions.StringSegment.Empty" xml:space="preserve">
         <value>Source StringSegment cannot be null or empty.</value>
     </data>
+    <data name="Exceptions.StringSegment.NullOrWhitespace" xml:space="preserve">
+        <value>Source StringSegment cannot be null or whitespace.</value>
+    </data>
 </root>

--- a/src/EnhancedLinq/MsExtensions/Deferred/DeferredSegmentEnumerationExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Deferred/DeferredSegmentEnumerationExtensions.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/. 
     */
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Deferred;
 
 /// <summary>
@@ -24,8 +26,7 @@ public static class DeferredSegmentEnumerationExtensions
         /// <exception cref="ArgumentException">Thrown if the StringSegment is null or empty.</exception>
         public IEnumerable<char> AsEnumerable()
         {
-            ArgumentException.ThrowIfNullOrEmpty(segment);
-            ArgumentException.ThrowIfNullOrWhitespace(segment);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(segment);
 
             return new CustomEnumeratorEnumerable<char>(new SegmentEnumerator(segment));
         }

--- a/src/EnhancedLinq/MsExtensions/Deferred/DeferredSegmentGroupExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Deferred/DeferredSegmentGroupExtensions.cs
@@ -9,6 +9,8 @@
 
 using System.Linq;
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Deferred;
 
 /// <summary>
@@ -29,7 +31,7 @@ public static class DeferredSegmentGroupExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="target"/> is null or empty.</exception>
         public IEnumerable<IGrouping<TKey, char>> GroupBy<TKey>(Func<char, TKey> predicate)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(target);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(target);
             ArgumentNullException.ThrowIfNull(predicate);
         
             return new CustomEnumeratorEnumerable<IGrouping<TKey, char>>(

--- a/src/EnhancedLinq/MsExtensions/Deferred/DeferredSegmentIndicesOfExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Deferred/DeferredSegmentIndicesOfExtensions.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/. 
     */
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Deferred;
 
 /// <summary>
@@ -25,7 +27,7 @@ public static class DeferredSegmentIndicesOfExtensions
         /// <exception cref="ArgumentException">Thrown if the source is null or empty.</exception>
         public IEnumerable<int> IndicesOf(char c)
         {
-            ArgumentException.ThrowIfNullOrEmpty(source);
+            StringSegmentGuard.ThrowIfNullOrEmpty(source);
 
             return new SegmentIndicesEnumerable(source, c);
         }
@@ -38,7 +40,7 @@ public static class DeferredSegmentIndicesOfExtensions
         /// <exception cref="ArgumentException">Thrown if the source is null or empty.</exception>
         public IEnumerable<int> IndicesOf(StringSegment segment)
         {
-            ArgumentException.ThrowIfNullOrEmpty(source);
+            StringSegmentGuard.ThrowIfNullOrEmpty(source);
 
             return new SegmentIndicesEnumerable(source, segment);
         }

--- a/src/EnhancedLinq/MsExtensions/Deferred/DeferredSegmentSplitExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Deferred/DeferredSegmentSplitExtensions.cs
@@ -8,7 +8,7 @@
     */
 
 
-using DotExtensions.MsExtensions.Primitives;
+using EnhancedLinq.MsExtensions.Internals;
 
 namespace EnhancedLinq.MsExtensions.Deferred;
 
@@ -27,7 +27,7 @@ public static class DeferredSegmentSplitExtensions
         /// <returns>An <see cref="IEnumerable{StringSegment}"/> containing the split segments. Returns an empty sequence if the separator is not found.</returns>
         public IEnumerable<StringSegment> SplitBy(char separator)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(source);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(source);
             
             return source.SplitBy(x => x == separator);
         }
@@ -40,10 +40,10 @@ public static class DeferredSegmentSplitExtensions
         /// <exception cref="ArgumentException">Thrown if the separator or the source is null or empty.</exception>
         public IEnumerable<StringSegment> SplitBy(StringSegment separator)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(source);
-            ArgumentException.ThrowIfNullOrWhitespace(separator);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(source);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(separator);
             
-            if (!source.Contains(separator))
+            if (source.AsSpan().IndexOf(separator.AsSpan()) < 0)
                 return [source];
         
             return new SegmentSplitEnumerable(source, separator);
@@ -56,7 +56,7 @@ public static class DeferredSegmentSplitExtensions
         /// <returns>An <see cref="IEnumerable{StringSegment}"/> containing the split segments.</returns>
         public IEnumerable<StringSegment> SplitBy(Func<char, bool> predicate)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(source);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
             return new CustomEnumeratorEnumerable<StringSegment>

--- a/src/EnhancedLinq/MsExtensions/Deferred/DeferredSegmentWhereExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Deferred/DeferredSegmentWhereExtensions.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/. 
     */
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Deferred;
 
 /// <summary>
@@ -24,7 +26,7 @@ public static class DeferredSegmentWhereExtensions
         /// <returns>An IEnumerable of chars that matches the predicate.</returns>
         public IEnumerable<char> Where(Func<char, bool> predicate)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(target);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(target);
             ArgumentNullException.ThrowIfNull(predicate);
 
             return new CustomEnumeratorEnumerable<char>(new WhereSegmentEnumerator(target, predicate));

--- a/src/EnhancedLinq/MsExtensions/GlobalUsings.cs
+++ b/src/EnhancedLinq/MsExtensions/GlobalUsings.cs
@@ -1,2 +1,1 @@
-﻿global using DotExtensions.MsExtensions.Exceptions;
 global using Microsoft.Extensions.Primitives;

--- a/src/EnhancedLinq/MsExtensions/Immediate/ImmediateCountAtMostExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Immediate/ImmediateCountAtMostExtensions.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/. 
     */
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Immediate;
 
 /// <summary>
@@ -25,7 +27,7 @@ public static class ImmediateCountAtMostExtensions
         /// <returns>True if there are at most <paramref name="countToLookFor"/> number of elements, false otherwise.</returns>
         public bool CountAtMost(int countToLookFor)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(source);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(source);
             ArgumentOutOfRangeException.ThrowIfNegative(countToLookFor);
 
             return source.Length <= countToLookFor;
@@ -40,7 +42,7 @@ public static class ImmediateCountAtMostExtensions
         public bool CountAtMost(Func<char, bool> predicate,
             int countToLookFor)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(source);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(source);
             ArgumentNullException.ThrowIfNull(predicate);
             ArgumentOutOfRangeException.ThrowIfNegative(countToLookFor);
 

--- a/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentAllExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentAllExtensions.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/. 
     */
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Immediate;
 
 /// <summary>
@@ -27,7 +29,7 @@ public static class ImmediateSegmentAllExtensions
             bool previousValue = predicate(target.First());
             
             ArgumentNullException.ThrowIfNull(predicate);
-            ArgumentException.ThrowIfNullOrWhitespace(target);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(target);
 
             for (int index = 0; index < target.Length; index++)
             {

--- a/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentAnyExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentAnyExtensions.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/. 
     */
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Immediate;
 
 /// <summary>
@@ -32,7 +34,7 @@ public static class ImmediateSegmentAnyExtensions
         /// <returns>True if any char in the StringSegment matches the predicate; false otherwise.</returns>
         public bool Any(Func<char, bool> predicate)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(target);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(target);
             ArgumentNullException.ThrowIfNull(predicate);
 
             for (int i = 0; i < target.Length; i++)

--- a/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentCountAtLeastExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentCountAtLeastExtensions.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/. 
     */
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Immediate;
 
 /// <summary>
@@ -24,7 +26,7 @@ public static class ImmediateSegmentCountAtLeastExtensions
         /// <returns><see langword="true"/> if there is at least the specified number of elements in the <see cref="StringSegment"/>; otherwise, <see langword="false"/>.</returns>
         public bool CountAtLeast(int countToLookFor)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(source);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(source);
             ArgumentOutOfRangeException.ThrowIfNegative(countToLookFor);
             
             return source.Length >= countToLookFor;
@@ -39,7 +41,7 @@ public static class ImmediateSegmentCountAtLeastExtensions
         public bool CountAtLeast(Func<char, bool> predicate,
             int countToLookFor)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(source);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(source);
             ArgumentNullException.ThrowIfNull(predicate);
             ArgumentOutOfRangeException.ThrowIfNegative(countToLookFor);
         

--- a/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentCountExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentCountExtensions.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/. 
     */
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Immediate;
 
 /// <summary>
@@ -25,7 +27,7 @@ public static class ImmediateSegmentCountExtensions
         /// <returns>The number of chars matching the predicate condition as an integer.</returns>
         public int Count(Func<char, bool> predicate)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(target);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(target);
             ArgumentNullException.ThrowIfNull(predicate);
             
             int output = 0;

--- a/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentFirstAndLastExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentFirstAndLastExtensions.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/. 
     */
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Immediate;
 
 /// <summary>
@@ -24,7 +26,7 @@ public static class ImmediateSegmentFirstAndLastExtensions
         /// <exception cref="InvalidOperationException">Thrown if the StringSegment contains zero chars.</exception>
         public char First()
         {
-            ArgumentException.ThrowIfNullOrEmpty(target);
+            StringSegmentGuard.ThrowIfNullOrEmpty(target);
 
             return target[0];
         }
@@ -44,7 +46,7 @@ public static class ImmediateSegmentFirstAndLastExtensions
         /// <exception cref="ArgumentException">Thrown if no characters in the StringSegment meet the predicate condition.</exception>
         public char First(Func<char, bool> predicate)
         {
-            ArgumentException.ThrowIfNullOrEmpty(target);
+            StringSegmentGuard.ThrowIfNullOrEmpty(target);
             ArgumentNullException.ThrowIfNull(predicate);
             
             for (int index = 0; index < target.Length; index++)
@@ -85,7 +87,7 @@ public static class ImmediateSegmentFirstAndLastExtensions
         /// <exception cref="InvalidOperationException">Thrown if the StringSegment contains zero chars.</exception>
         public char Last()
         {
-            ArgumentException.ThrowIfNullOrEmpty(target);
+            StringSegmentGuard.ThrowIfNullOrEmpty(target);
 
             return target[^1];
         }
@@ -109,7 +111,7 @@ public static class ImmediateSegmentFirstAndLastExtensions
         /// <exception cref="ArgumentException">Thrown if no characters in the StringSegment meet the predicate condition.</exception>
         public char Last(Func<char, bool> predicate)
         {
-            ArgumentException.ThrowIfNullOrEmpty(target);
+            StringSegmentGuard.ThrowIfNullOrEmpty(target);
             ArgumentNullException.ThrowIfNull(predicate);
         
             for (int i = target.Length - 1; i >= 0; i--)

--- a/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentForEachExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentForEachExtensions.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/. 
     */
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Immediate;
 
 /// <summary>
@@ -23,7 +25,7 @@ public static class ImmediateSegmentForEachExtensions
         /// <param name="action">The action to apply to each <see cref="char"/> in the <see cref="StringSegment"/>.</param>
         public void ForEach(Action<char> action)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(target);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(target);
 
             for (int index = 0; index < target.Length; index++)
             {
@@ -37,7 +39,7 @@ public static class ImmediateSegmentForEachExtensions
         /// <param name="action">The func to apply to each element in the <see cref="StringSegment"/>.</param>
         public void ForEach(Func<char, char> action)
         {
-            ArgumentException.ThrowIfNullOrWhitespace(target);
+            StringSegmentGuard.ThrowIfNullOrWhitespace(target);
             ArgumentNullException.ThrowIfNull(action);
             
             char[] output = new char[target.Length];

--- a/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentIndicesExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentIndicesExtensions.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/. 
     */
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Immediate;
 
 /// <summary>
@@ -42,7 +44,7 @@ public static class ImmediateSegmentIndicesExtensions
         /// <returns>A list containing the zero-based index positions where the specified <see cref="StringSegment"/> was found in the <see cref="StringSegment"/>.</returns>
         public IList<int> IndicesOf(StringSegment other)
         {
-            ArgumentException.ThrowIfNullOrEmpty(segment);
+            StringSegmentGuard.ThrowIfNullOrEmpty(segment);
 
             List<int> output = new(segment.Length);
 

--- a/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentSplitExtensions.cs
+++ b/src/EnhancedLinq/MsExtensions/Immediate/ImmediateSegmentSplitExtensions.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/. 
     */
 
+using EnhancedLinq.MsExtensions.Internals;
+
 namespace EnhancedLinq.MsExtensions.Immediate;
 
 /// <summary>
@@ -51,7 +53,7 @@ public static class ImmediateSegmentSplitExtensions
         /// <returns>An array of StringSegment subsegments from the source StringSegment that is delimited by the separator.</returns>
         public StringSegment[] Split(StringSegment separator)
         {
-            ArgumentException.ThrowIfNullOrEmpty(separator);
+            StringSegmentGuard.ThrowIfNullOrEmpty(separator);
 
             IList<int> indices = source.IndicesOf(separator);
 

--- a/src/EnhancedLinq/MsExtensions/Internals/StringSegmentGuard.cs
+++ b/src/EnhancedLinq/MsExtensions/Internals/StringSegmentGuard.cs
@@ -1,0 +1,27 @@
+/*
+    EnhancedLinq 
+    Copyright (c) 2025-2026 Alastair Lundy
+    
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/. 
+    */
+
+using EnhancedLinq.Internals.Localizations;
+
+namespace EnhancedLinq.MsExtensions.Internals;
+
+internal static class StringSegmentGuard
+{
+    internal static void ThrowIfNullOrEmpty(in StringSegment segment)
+    {
+        if (!segment.HasValue || segment.Length == 0)
+            throw new ArgumentException(Resources.Exceptions_StringSegment_Empty);
+    }
+
+    internal static void ThrowIfNullOrWhitespace(in StringSegment segment)
+    {
+        if (!segment.HasValue || segment.AsSpan().IsWhiteSpace())
+            throw new ArgumentException(Resources.Exceptions_StringSegment_NullOrWhitespace);
+    }
+}


### PR DESCRIPTION
DotExtensions provided a handful of small utilities that EnhancedLinq depended on, but the surface area we used was narrow enough that the dependency didn't earn its keep. This PR replaces those APIs with inline implementations or BCL equivalents, removing the DotExtensions package references entirely.

## Approach

Most replacements map directly to BCL APIs available in .NET 8+:

- `ToNumber<T>()` and `ToDestinationNumber<>()` → `TNumber.CreateTruncating()` (used in average and range extensions)
- `ThrowIfSpanIsEmpty` / `ThrowIfMemoryIsEmpty` → inline `if (x.IsEmpty) throw` guards with existing resource strings
- `Span.Resize()` → inline array allocation and copy in `ImmediateMemoryInsertRangeExtensions`
- `IsIncrementedNumberRange()` → private helper method in `ImmediateMemoryGetRangeExtensions`
- `StringSegment.Contains()` → `AsSpan().IndexOf()` in `DeferredSegmentSplitExtensions`

For `StringSegment` argument validation, I introduced an internal `StringSegmentGuard` helper class in `MsExtensions/Internals/` that provides `ThrowIfNullOrEmpty` and `ThrowIfNullOrWhitespace` methods. This centralizes the validation logic that was previously spread across ~15 call sites.

The `StringSegment.SplitBy()` overloads remain public as requested, now self-contained without the DotExtensions import.

## What changed

- Removed `DotExtensions` and `DotExtensions.Memory` package references from all three `.csproj` files
- Removed corresponding `PackageVersion` entries from `Directory.Packages.props`
- Removed all `global using DotExtensions.*` directives
- Added `StringSegmentGuard` internal helper class
- Added resource string `Exceptions.StringSegment.NullOrWhitespace` for the new validation helper
- Wrapped `ElementsAt(Range)` in `#if !NETSTANDARD2_0` to fix a pre-existing accessibility issue on netstandard2.0

## Verification

Build succeeds across all target frameworks (net10.0, net9.0, net8.0, netstandard2.0) with zero errors.

Test results:
- EnhancedLinq.Memory.Tests: 42/42 passing
- EnhancedLinq.Tests: 326/327 passing (1 pre-existing net10.0-specific flaky test in `ContainsDuplicates_AllSameElements_ReturnsTrue`, unrelated to these changes)

## Notes

The `ElementsAt(Range)` fix was necessary because `Range` is not available on netstandard2.0, but the method was previously exposed without a target framework guard, causing an accessibility error. This was a latent bug exposed by the build after removing DotExtensions.